### PR TITLE
feat(certbot): configure certbot for storage subdomain and renewals

### DIFF
--- a/Dockerfile.certbot-renew
+++ b/Dockerfile.certbot-renew
@@ -1,0 +1,3 @@
+FROM certbot/certbot
+
+RUN apk add --no-cache docker-cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,17 +141,21 @@ services:
       "--no-eff-email",
       "-d", "${DOMAIN}",
       "-d", "www.${DOMAIN}",
-      "-d", "storage.${DOMAIN}"
+      "-d", "storage.${DOMAIN}",
+      "--expand"
     ]
 
   certbot-renew:
-    image: certbot/certbot
+    build:
+      context: .
+      dockerfile: Dockerfile.certbot-renew
     container_name: certbot_renew
     volumes:
       - certbot-etc:/etc/letsencrypt
       - certbot-var:/var/lib/letsencrypt
       - ./certbot-www:/var/www/certbot
-    entrypoint: sh -c "while :; do certbot renew --webroot -w /var/www/certbot && docker exec nginx_container nginx -s reload; sleep 12h; done"
+      - /var/run/docker.sock:/var/run/docker.sock
+    entrypoint: sh -c "while :; do certbot renew --webroot -w /var/www/certbot && docker exec nginx nginx -s reload; sleep 12h; done"
     restart: unless-stopped
     networks:
       - common_network

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,7 @@ http {
 
     server {
         listen 80;
-        server_name expenses-tracker.online www.expenses-tracker.online;
+        server_name expenses-tracker.online www.expenses-tracker.online storage.expenses-tracker.online;
 
          location /.well-known/acme-challenge/ {
             root /var/www/certbot;
@@ -90,8 +90,8 @@ http {
         listen 443 ssl;
         server_name storage.expenses-tracker.online;
 
-        ssl_certificate /etc/letsencrypt/live/storage.example.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/storage.example.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/storage.expenses-tracker.online/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/storage.expenses-tracker.online/privkey.pem;
 
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers HIGH:!aNULL:!MD5;


### PR DESCRIPTION
- add storage subdomain to nginx configuration
- create Dockerfile for certbot renewal with Docker CLI
- update docker-compose for certbot renewal service