### PR TITLE
feat(metrics): add internal MinIO endpoint and refactor storage client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ MINIO_ACCESS_KEY=minio
 MINIO_SECRET_KEY=minio123
 MINIO_BUCKET=avatars
 MINIO_PUBLIC_ENDPOINT=https://storage.example.com
+MINIO_INTERNAL_ENDPOINT=http://minio:9000
 SENTRY_DSN=https://ur-key-1.ingest.de.sentry.io/ur-key-2
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      nginx:
+      minio:
         condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/api/health\")' || exit 1" ]
-      interval: 30s
+      interval: 20s
       timeout: 10s
       retries: 3
       start_period: 40s
@@ -147,7 +147,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx.local.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - certbot-etc:/etc/letsencrypt
       - certbot-var:/var/lib/letsencrypt
       - ./certbot-www:/var/www/certbot
@@ -155,7 +155,7 @@ services:
     networks:
       - common_network
     depends_on:
-      minio:
+      api:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost/ || exit 1"]
@@ -327,6 +327,7 @@ services:
 
   tempo-init:
     image: grafana/tempo:latest
+    container_name: tempo_init
     user: root
     entrypoint: [ "chown" ]
     command: [ "-R", "10001:10001", "/var/tempo" ]

--- a/expenses_tracker/core/settings.py
+++ b/expenses_tracker/core/settings.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     categories_list_ttl_seconds: int = 60 * 30
 
     minio_public_endpoint: str = "https://storage.example.com"
+    minio_internal_endpoint: str = "http://minio:9000"
     minio_root_user: str = "minio"
     minio_root_password: str = "minio123"
     minio_avatar_bucket: str = "avatars"


### PR DESCRIPTION
- introduce MINIO_INTERNAL_ENDPOINT in settings and .env.example
- refactor MinioAvatarStorage to use internal and public clients